### PR TITLE
Automatically update graph when new files are added (#34)Automatically update graph when new files are added (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] – 2020-07-25
+
+### Added
+
+- Extensions to look for can now be specified in settings ([#31](https://github.com/tchayen/markdown-links/pull/31)).
+- Configurable autostart ([#14](https://github.com/tchayen/markdown-links/pull/14)).
+
+### Fixed
+
+- Graph should now properly update on adding a new file ([#34](https://github.com/tchayen/markdown-links/pull/34)).
+- Wrong active node size when zooming ([#20](https://github.com/tchayen/markdown-links/pull/20)).
+
 ## [0.6.0] – 2020-06-26
 
 ### Added
 
-- Support for [file-name] ids. A format where id of a file is its name (works either with or without `.md` extension).
+- Support for [file-name] ids. A format where id of a file is its name (works either with or without `.md` extension) ([#13](https://github.com/tchayen/markdown-links/pull/13)).
 
 ### Fixed
 
-- Active node highlight should work better on Windows.
+- Active node highlight should work better on Windows ([#10](https://github.com/tchayen/markdown-links/pull/10)).
 
 ### Changed
 
-- Extension will now pick colors of your theme. It should give much more consistent look in majority of cases, but inevitably means that it might also break. Let us know in issues if something is wrong.
+- Extension will now pick colors of your theme ([#10](https://github.com/tchayen/markdown-links/pull/10)).
 
 ## [0.5.0] – 2020-05-23
 
@@ -29,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for wiki-style links using `[[link]]` format and corresponding `fileIdRegexp` setting for specifying regular expression for resolving file IDs – [d3254f68](https://github.com/tchayen/markdown-links/commit/d3254f687c4cc0a9b11f218dddc5069bb4898cbe).
+- Support for wiki-style links using `[[link]]` format and corresponding `fileIdRegexp` setting for specifying regular expression for resolving file IDs – ([#3](https://github.com/tchayen/markdown-links/pull/3)).
 
 ## [0.3.0] - 2020-05-22
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,13 @@ const watch = (
     sendGraph();
   });
 
+  // Watch file creation in case user adds a new file
+  watcher.onDidCreate(async (event) => {
+    await parseFile(graph, event.path);
+    filterNonExistingEdges(graph);
+    sendGraph();
+  });
+
   watcher.onDidDelete(async (event) => {
     const index = graph.nodes.findIndex((node) => node.path === event.path);
     if (index === -1) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,22 @@
 import * as vscode from "vscode";
 import * as md5 from "md5";
+import { extname } from "path";
 import { MarkdownNode, Graph } from "./types";
 
 export const findLinks = (ast: MarkdownNode): string[] => {
   if (ast.type === "link" || ast.type === "definition") {
-    return [ast.url!];
+    // ignore empty, anchor and web links
+    if (
+      !ast.url ||
+      ast.url.startsWith("#") ||
+      vscode.Uri.parse(ast.url).scheme.startsWith("http")
+    ) {
+      return [];
+    }
+
+    return [ast.url];
   }
+
   if (ast.type === "wikiLink") {
     return [ast.data!.permalink!];
   }
@@ -42,12 +53,8 @@ export const findTitle = (ast: MarkdownNode): string | null => {
 };
 
 export const id = (path: string): string => {
-  return md5(path);
-
-  // Extracting file name without extension:
-  // const fullPath = path.split("/");
-  // const fileName = fullPath[fullPath.length - 1];
-  // return fileName.split(".")[0];
+  // Extracting file name without extension
+  return md5(path.substring(0, path.length - extname(path).length));
 };
 
 export const getConfiguration = (key: string) =>


### PR DESCRIPTION
* Normalize graph node paths

Previously, the node id was formed of path with extension for files
that were ingested into the graph on startup, and without path for
files and links that were added after the fact (because no path info
is available, unless it's explicitly provided in wiki-link lavel or
link reference definition.

Also remove anchor and http links from the link array, since they
will never match any nodes.

* Add new files to the graph as they are added* Normalize graph node paths

Previously, the node id was formed of path with extension for files
that were ingested into the graph on startup, and without path for
files and links that were added after the fact (because no path info
is available, unless it's explicitly provided in wiki-link lavel or
link reference definition.

Also remove anchor and http links from the link array, since they
will never match any nodes.

* Add new files to the graph as they are added* Normalize graph node paths

Previously, the node id was formed of path with extension for files
that were ingested into the graph on startup, and without path for
files and links that were added after the fact (because no path info
is available, unless it's explicitly provided in wiki-link lavel or
link reference definition.

Also remove anchor and http links from the link array, since they
will never match any nodes.

* Add new files to the graph as they are added